### PR TITLE
Fix error invoking git which happens on all of my Windows systems.

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -4,17 +4,21 @@ import subprocess
 
 def execute_command(command, working_dir=None):
     startupinfo = None
+    stdpipe = None
     # hide console window on windows
     if os.name == 'nt':
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        stdpipe = subprocess.PIPE
 
     output = None
     try:
         output = subprocess.check_output(
             command,
             cwd=working_dir,
-            startupinfo=startupinfo
+            startupinfo=startupinfo,
+            stdin=stdpipe,
+            stderr=stdpipe
         )
     except (subprocess.CalledProcessError, AttributeError):
         # Git will return an error when the given directory


### PR DESCRIPTION
Trying to invoke git always throws the following error to my
console:

OSError: [WinError 6] The handle is invalid

Populating stdin/stderr with subprocess.PIPE fixes the problem.  I
think this is the following Python bug:

https://bugs.python.org/issue3905
